### PR TITLE
Terminate trigger

### DIFF
--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>715</width>
+    <width>785</width>
     <height>526</height>
    </rect>
   </property>
@@ -3732,7 +3732,7 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
             </font>
            </property>
            <property name="currentIndex">
-            <number>4</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="tabMisc">
             <attribute name="title">
@@ -3849,8 +3849,8 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
              <property name="bottomMargin">
               <number>3</number>
              </property>
-             <item row="15" column="1">
-              <widget class="QToolButton" name="btnAddDeleteCmd">
+             <item row="21" column="1">
+              <widget class="QToolButton" name="btnDelAuto">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -3863,11 +3863,21 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
                  <height>23</height>
                 </size>
                </property>
+               <property name="text">
+                <string>Remove</string>
+               </property>
+              </widget>
+             </item>
+             <item row="13" column="1">
+              <widget class="QLabel" name="label_68">
                <property name="toolTip">
-                <string>This command will be run before the box content will be deleted</string>
+                <string>These commands are run UNBOXED just before the box content is deleted</string>
                </property>
                <property name="text">
-                <string>Run Command</string>
+                <string>On File Recovery</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
@@ -3890,7 +3900,46 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
                </property>
               </widget>
              </item>
-             <item row="1" column="0" rowspan="18">
+             <item row="1" column="1">
+              <widget class="QLabel" name="label_66">
+               <property name="toolTip">
+                <string>These commands are executed only when a box is initialized. To make them run again, the box content must be deleted.</string>
+               </property>
+               <property name="text">
+                <string>On Box Init</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="1">
+              <spacer name="verticalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="16" column="1">
+              <widget class="QLabel" name="label_67">
+               <property name="toolTip">
+                <string>These commands are run UNBOXED just before the box content is deleted</string>
+               </property>
+               <property name="text">
+                <string>On Delete Content</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" rowspan="21">
               <widget class="QTreeWidget" name="treeTriggers">
                <property name="sortingEnabled">
                 <bool>true</bool>
@@ -3913,26 +3962,29 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
               </widget>
              </item>
              <item row="11" column="1">
-              <widget class="QLabel" name="label_68">
+              <widget class="QLabel" name="label_18">
                <property name="toolTip">
-                <string>These commands are run UNBOXED just before the box content is deleted</string>
+                <string>This command runs after all processes in the sandbox have finished.</string>
                </property>
                <property name="text">
-                <string>On File Recovery</string>
+                <string>On Box Terminate</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
-             <item row="17" column="1">
-              <widget class="QCheckBox" name="chkShowTriggersTmpl">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_32">
                <property name="text">
-                <string>Show Templates</string>
+                <string>Here you can specify actions to be executed automatically on various box events.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="12" column="1">
+             <item row="15" column="1">
               <widget class="QToolButton" name="btnAddRecoveryCmd">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -3954,80 +4006,6 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
                </property>
               </widget>
              </item>
-             <item row="18" column="1">
-              <widget class="QToolButton" name="btnDelAuto">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>23</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Remove</string>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="1">
-              <spacer name="verticalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLabel" name="label_66">
-               <property name="toolTip">
-                <string>These commands are executed only when a box is initialized. To make them run again, the box content must be deleted.</string>
-               </property>
-               <property name="text">
-                <string>On Box Init</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_32">
-               <property name="text">
-                <string>Here you can specify actions to be executed automatically on various box events.</string>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QToolButton" name="btnAddAutoExec">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>23</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Run Command</string>
-               </property>
-              </widget>
-             </item>
              <item row="8" column="1">
               <widget class="QLabel" name="label_33">
                <property name="toolTip">
@@ -4038,6 +4016,35 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
                </property>
                <property name="alignment">
                 <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="18" column="1">
+              <widget class="QToolButton" name="btnAddDeleteCmd">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>23</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>This command will be run before the box content will be deleted</string>
+               </property>
+               <property name="text">
+                <string>Run Command</string>
+               </property>
+              </widget>
+             </item>
+             <item row="20" column="1">
+              <widget class="QCheckBox" name="chkShowTriggersTmpl">
+               <property name="text">
+                <string>Show Templates</string>
                </property>
               </widget>
              </item>
@@ -4060,16 +4067,41 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
                </property>
               </widget>
              </item>
-             <item row="13" column="1">
-              <widget class="QLabel" name="label_67">
-               <property name="toolTip">
-                <string>These commands are run UNBOXED just before the box content is deleted</string>
+             <item row="2" column="1">
+              <widget class="QToolButton" name="btnAddAutoExec">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>23</height>
+                </size>
                </property>
                <property name="text">
-                <string>On Delete Content</string>
+                <string>Run Command</string>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+              </widget>
+             </item>
+             <item row="12" column="1">
+              <widget class="QToolButton" name="btnAddTerminateCmd">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>23</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Run Command</string>
                </property>
               </widget>
              </item>
@@ -4473,8 +4505,8 @@ instead of &quot;*&quot;.</string>
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>92</width>
+                  <height>16</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="dbgLayout">

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -2258,6 +2258,13 @@ void CSandMan::OnStartMenuChanged()
 
 void CSandMan::OnBoxClosed(const CSandBoxPtr& pBox)
 {
+	foreach(const QString & Value, pBox->GetTextList("OnBoxTerminate", true, false, true)) {
+		QString Value2 = pBox->Expand(Value);
+		CSbieProgressPtr pProgress = CSbieUtils::RunCommand(Value2, true);
+		if (!pProgress.isNull()) {
+			AddAsyncOp(pProgress, true, tr("Executing OnBoxTerminate: %1").arg(Value2));
+		}
+	}
 	if (!pBox->GetBool("NeverDelete", false))
 	{
 		if (pBox->GetBool("AutoDelete", false))

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -430,7 +430,7 @@ void COptionsWindow::SaveAdvanced()
 	WriteTextList("AutoExec", AutoExec);
 	WriteTextList("OnFileRecovery", RecoveryCheck);
 	WriteTextList("OnBoxDelete", DeleteCommand);
-	WriteTextList("OnBoxTerimate", TerminateCommand);
+	WriteTextList("OnBoxTerminate", TerminateCommand);
 	//
 
 

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -89,6 +89,7 @@ void COptionsWindow::CreateAdvanced()
 	connect(ui.btnAddAutoExec, SIGNAL(clicked(bool)), this, SLOT(OnAddAutoExec()));
 	connect(ui.btnAddRecoveryCmd, SIGNAL(clicked(bool)), this, SLOT(OnAddRecoveryCheck()));
 	connect(ui.btnAddDeleteCmd, SIGNAL(clicked(bool)), this, SLOT(OnAddDeleteCmd()));
+	connect(ui.btnAddTerminateCmd, SIGNAL(clicked(bool)), this, SLOT(OnAddTerminateCmd()));
 	connect(ui.btnDelAuto, SIGNAL(clicked(bool)), this, SLOT(OnDelAuto()));
 	connect(ui.chkShowTriggersTmpl, SIGNAL(clicked(bool)), this, SLOT(OnShowTriggersTmpl()));
 
@@ -411,6 +412,7 @@ void COptionsWindow::SaveAdvanced()
 	QStringList RecoveryCheck;
 	QStringList DeleteCommand;
 	QStringList AutoExec;
+	QStringList TerminateCommand;
 	for (int i = 0; i < ui.treeTriggers->topLevelItemCount(); i++) {
 		QTreeWidgetItem* pItem = ui.treeTriggers->topLevelItem(i);
 		switch (pItem->data(0, Qt::UserRole).toInt())
@@ -420,6 +422,7 @@ void COptionsWindow::SaveAdvanced()
 		case eAutoExec:		AutoExec.append(pItem->text(2)); break;
 		case eRecoveryCheck:		RecoveryCheck.append(pItem->text(2)); break;
 		case eDeleteCmd:	DeleteCommand.append(pItem->text(2)); break;
+		case eTerminateCmd:		TerminateCommand.append(pItem->text(2)); break;
 		}
 	}
 	WriteTextList("StartProgram", StartProgram);
@@ -427,6 +430,7 @@ void COptionsWindow::SaveAdvanced()
 	WriteTextList("AutoExec", AutoExec);
 	WriteTextList("OnFileRecovery", RecoveryCheck);
 	WriteTextList("OnBoxDelete", DeleteCommand);
+	WriteTextList("OnBoxTerimate", TerminateCommand);
 	//
 
 
@@ -874,6 +878,9 @@ void COptionsWindow::AddTriggerItem(const QString& Value, ETriggerAction Type, c
 			pItem->setText(0, tr("On Delete Content"));
 			pItem->setText(1, tr("Run Command"));
 			break;
+		case eTerminateCmd:
+			pItem->setText(0, tr("On Terminate"));
+			pItem->setText(1, tr("Run Command"));
 	}
 	pItem->setText(2, Value);
 	pItem->setFlags(pItem->flags() | Qt::ItemIsEditable);
@@ -920,6 +927,17 @@ void COptionsWindow::OnAddDeleteCmd()
 		return;
 
 	AddTriggerItem(Value, eDeleteCmd);
+	m_AdvancedChanged = true;
+	OnOptChanged();
+}
+
+void COptionsWindow::OnAddTerminateCmd()
+{
+	QString Value = QInputDialog::getText(this, "Sandboxie-Plus", tr("Please enter the command line to be executed"), QLineEdit::Normal);
+	if (Value.isEmpty())
+		return;
+
+	AddTriggerItem(Value, eTerminateCmd);
 	m_AdvancedChanged = true;
 	OnOptChanged();
 }

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -191,6 +191,7 @@ private slots:
 	void OnAddAutoExec();
 	void OnAddRecoveryCheck();
 	void OnAddDeleteCmd();
+	void OnAddTerminateCmd();
 	void OnDelAuto();
 
 	void OnAddProcess();
@@ -334,7 +335,8 @@ public:
 		eOnStartSvc,
 		eAutoExec,
 		eRecoveryCheck,
-		eDeleteCmd
+		eDeleteCmd,
+		eTerminateCmd
 	};
 
 	static QString AccessTypeToName(EAccessEntry Type);


### PR DESCRIPTION

The “OptionWindows.UI” file was modified by using the designer.
The code for this trigger has been added in“OptionsAdvanced. CPP”.
In the“OnBoxClosed” function of“Sandman. CPP”, I added the actual trigger firing code (in theory, synchronous rather than asynchronous execution)